### PR TITLE
fix: cannot compiler because of missing header file cstdint

### DIFF
--- a/include/ravel/instructions.h
+++ b/include/ravel/instructions.h
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>

--- a/include/ravel/interpreter/libc_sim.h
+++ b/include/ravel/interpreter/libc_sim.h
@@ -7,6 +7,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <cstdio>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
I cannot build the original version on my computer. This commit fixes it by adding the missing header file (`cstdint`).

GCC version: 13.1.1
CMake version: 3.27.1