### PR TITLE
fix: wrong memory range check

### DIFF
--- a/src/interpreter/cache.cpp
+++ b/src/interpreter/cache.cpp
@@ -6,7 +6,7 @@ namespace ravel {
 
 std::uint32_t Cache::fetchWord(std::size_t addr) {
   std::size_t memorySize = storageEnd - storageBegin;
-  if (addr + 3 > memorySize) {
+  if (addr + 4 > memorySize) {
     throw InvalidAddress(addr);
   }
   if (disabled) {


### PR DESCRIPTION
For the following code:
```asm
    .section text
    .globl main
main:
    addi sp, sp, -16
    lbu a0, 15(sp)
   ret
```
The previous version will throw an error `ravel::InvalidAddress`, indicating the memory access is invalid. This is caused by the mechanism of `lbu` - ravel will read four bytes from the beginning address, which is unnecessary.

This patch fixes the problem.