### PR TITLE
fix(assembler): word type cannot be negative numbers

### DIFF
--- a/src/assembler/assembler.cpp
+++ b/src/assembler/assembler.cpp
@@ -220,7 +220,8 @@ private:
       assert(tokens.size() == 2);
       auto curPos = storage.size();
       storage.resize(storage.size() + 4);
-      if (!std::isdigit(tokens.at(1).front())) { // .word label
+      if (!std::isdigit(tokens.at(1).front()) &&
+          tokens.at(1).front() != '-') { // .word label
         assert(curSection == Section::DATA);
         toBeStored.emplace_back(tokens.at(1), curPos);
         return;


### PR DESCRIPTION
If we want a global word to be negative number, the previous version will throw an exception either if you use a negative number like -1 or if you use a overflow trick like 4294967295. This commit fix the problem by allowing the negative number as the word literal.

For example, for the following code,
```asm
    .section text
    .globl main
main:
    ret

    .section .data
    .globl a
a:
   .word -1
```
The previous version will throw an error.
